### PR TITLE
Error value out of bounds changed to non-critical in partition entries reading

### DIFF
--- a/libvsgpt/libvsgpt_volume.c
+++ b/libvsgpt/libvsgpt_volume.c
@@ -1726,7 +1726,7 @@ int libvsgpt_internal_volume_read_partition_entries(
 			 "%s: invalid partition entry - start block number value out of bounds.",
 			 function );
 
-			goto on_error;
+			break;
 		}
 		if( ( partition_entry->end_block_number < partition_entry->start_block_number )
 		 || ( partition_entry->end_block_number > (uint64_t) ( internal_volume->size / internal_volume->io_handle->bytes_per_sector ) ) )
@@ -1738,7 +1738,7 @@ int libvsgpt_internal_volume_read_partition_entries(
 			 "%s: invalid partition entry - end block number value out of bounds.",
 			 function );
 
-			goto on_error;
+			break;
 		}
 		partition_values->entry_index = partition_entry_index;
 		partition_values->offset      = (off64_t) ( partition_entry->start_block_number * internal_volume->io_handle->bytes_per_sector );


### PR DESCRIPTION
Partition entries should not be cleared in case of ```LIBCERROR_ARGUMENT_ERROR_VALUE_OUT_OF_BOUNDS```, libcerror is filled and partitions list is returned.